### PR TITLE
Add Colima setup links in Docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ This section is meant to guide you during your learning period.
 
 *Estimate reading time: 2-3 hours*
 
+- [Replacing Docker Desktop for Mac with Colima](https://www.arthurkoziel.com/replacing-docker-desktop-for-mac-with-colima/)
+- [Colima setup for macOS](src/colima.md)
 - [Getting Started](https://www.youtube.com/watch?v=iqqDU2crIEQ&t=30s)
 - [Docker Talk](https://drive.google.com/file/d/1hPlXivcCRm5uPR8sn0P3lhnQ0eQqdPrV/view)
 

--- a/src/colima.md
+++ b/src/colima.md
@@ -1,0 +1,35 @@
+# Colima setup for macOS
+
+Install Colima and Docker, then start Colima:
+```bash
+brew install colima
+brew install docker
+echo "{ \"credStore\" : \"desktop\" }" > ~/.docker/config.json
+colima start
+```
+
+## Examples
+
+### uname
+
+```bash
+$ uname
+Darwin
+
+$ colima ssh -- uname
+Linux
+```
+
+### Sharing Files
+
+```bash
+$ echo "files under /Users on macOS filesystem are readable from Linux" > some-file
+
+$ colima ssh -- cat some-file
+files under /Users on macOS filesystem are readable from Linux
+
+$ colima ssh -- sh -c 'echo "/tmp/colima is writable from both macOS and Linux" > /tmp/colima/another-file'
+
+$ cat /tmp/colima/another-file
+/tmp/colima is writable from both macOS and Linux
+```


### PR DESCRIPTION
I've added links to install Colima in the Docker section. In this way, people won't have to install Docker Desktop.