### PR TITLE
Update Level 2 estimate times

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This section is meant to guide you during your learning period.
 
 ## Practice Level 2
 
-*Estimate time: 46-56 hours (assuming you read either 'Elixir in Action' or 'Phoenix in Action')*
+*Estimate time: 46-56 hours*
 
 ### Functional Programming
 


### PR DESCRIPTION
Now that 'Elixir in Action' has been removed from the learning path, I've updated Level 2 estimate times.