### PR TITLE
Remove Elixir in Action mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ It is considered good style - and sometimes a necessity - to always end files wi
 
 ## Practice Level 2
 
-*Estimate time: 46-56 hours (assuming you read either 'Elixir in Action' or 'Phoenix in Action')*
+*Estimate time: 46-56 hours (assuming you read 'Phoenix in Action')*
 
 ### Functional Programming
 


### PR DESCRIPTION
This can lead to confusion, since it was already removed from the learning path. I propose removing it.