### PR TITLE
Update kubernetes extra exercises.

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ Amazon Web Services (AWS) is the world’s most comprehensive and broadly adopte
 Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available.
 - [Getting started with kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/)
 - [Kubernetes Basics](https://kubernetes.io/docs/tutorials/kubernetes-basics/)
-- [Extra exercises](https://github.com/bregman-arie/devops-exercises/tree/master/exercises/kubernetes)
+- [Extra exercises](https://github.com/bregman-arie/devops-exercises/tree/master/topics/kubernetes/exercises)
 
 ### Continuous Integration
 


### PR DESCRIPTION
The previous link for "Extra exercises" inside the [Kubernetes](https://github.com/lambdaclass/lambdaclass_hacking_learning_path#kubernetes) section is broken.

***

### Previous link. 
<img width="1407" alt="image" src="https://github.com/lambdaclass/lambdaclass_hacking_learning_path/assets/53660242/3af014da-32f8-4b5c-a641-279fcc5b4f40">

***

### Updated link.
<img width="1413" alt="image" src="https://github.com/lambdaclass/lambdaclass_hacking_learning_path/assets/53660242/4185db8b-5444-447e-9ca9-a4abe80e2c88">

***

I replaced the link (same repo, resource was moved).