### PR TITLE
Replaced reference from Travis-CI to Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Use git and commit often, even in one-person projects.
 - Fill the description field at the top of the repo page.
 - Write a decent README.
 - A good readme starts with a succinct description (one or two sentences) and, when possible, a very short and illustrative example use. The rest of the details go after this header.
-- Use continuous integration, most likely travis.org.
+- Use continuous integration, most likely Github Actions.
 - Make a good balance of features vs maintenance. Maintenance details usually matter more than adding a lot of features.
 
 ## Slack channels


### PR DESCRIPTION
Replaced reference to Travis-CI with Github Actions because it is no longer our primary tool for CI