### PR TITLE
Expand SSH section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Before you embark on your Git journey, it is important to learn what an SSH Key 
 
 - [SSH Keys for GitHub](https://jdblischak.github.io/2014-09-18-chicago/novice/git/05-sshkeys.html)
 - [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+- [Authorizing an SSH key for use with SAML single sign-on](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on#)
 
 #### Git
 *Estimate reading time: 7-8 hours*


### PR DESCRIPTION
This commit adds a link to "Authorizing an SSH key for use with SAML single sign-on" from the Github documentation, as it is a necessary step to clone repositories.