### PR TITLE
Change presentation link to higher quality version

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ As with most projects making mistakes fast and loudly will make you learn faster
 We follow a code of conduct that must be followed to ensure a safe space in the team. You signed it when you entered Lambda and we expect you to follow it. Basically, treat everyone with respect.
 
 - [Principles for success by Ray Dalio](https://www.youtube.com/embed/B9XGUpQZY38).
-- [Charity Majors - The Sociotechnical Path to High-Performing Teams](https://www.youtube.com/watch?v=4lLl5B8Oazw).
+- [Charity Majors - The Sociotechnical Path to High-Performing Teams](https://www.youtube.com/watch?v=oV8VSBSBrr4).
 - [Antifragile: Things That Gain from Disorder](https://www.amazon.com/Antifragile-Things-That-Disorder-Incerto/dp/0812979680)
     - Chapters 1 & 15
 - [Citogenesis in science and the importance of real problems](https://lemire.me/blog/2023/06/14/citogenesis-in-science-and-the-importance-of-real-problems/)


### PR DESCRIPTION
Changes the link to the presentation: "The Sociotechnical Path to High-Performing Teams" by Charity Majors.

The same person did the same talk for another conference, and the video and audio quality is better.

[Old link](https://www.youtube.com/watch?v=4lLl5B8Oazw)

[New link](https://www.youtube.com/watch?v=oV8VSBSBrr4)