### PR TITLE
Delete dead Zruput link

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ We use Slack as our main source of communication between the teams and within th
 We organize activities where we share thoughts and interests with anyone who wants to join us.
 
 - [BuzzConf](https://buzzconf.org/) A conference for developers, by developers. Past talks [here](https://www.youtube.com/channel/UCE6_WdRbp8pN2IPNwXcu9Ww/videos).
-- [Zruput](https://zruput.org/) Digital Communications Conference.
 - [LambdaClass Blog](https://blog.lambdaclass.com/) Writings, reviews, and interviews about programming.
 - [Papers We Love Buenos Aires](https://github.com/papers-we-love/buenos-aires) Once a month we organize a meeting where we discuss scientific papers we love. Join us on [Telegram](https://t.me/pwlba).
 


### PR DESCRIPTION
The following link does not work anymore:

```
https://zruput.org/
```

This PR deletes the line that contains the link.