### PR TITLE
Update Phoenix section

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ $ cat /tmp/colima/another-file
   - Introduction
     - Except for _Community_
   - Guides
-    - Except for _Telemetry_ and _Asset Management_
+    - Except for _Asset Management_
   - Authentication
   - Testing
     - Except for _Testing Channels_

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ $ cat /tmp/colima/another-file
 - [StreamData: Property-based testing and data generation](https://elixir-lang.org/blog/2017/10/31/stream-data-property-based-testing-and-data-generation-for-elixir/)
 
 ### Phoenix
-- [Phoenix Official Guides](https://hexdocs.pm/phoenix/up_and_running.html)
+- [Phoenix Official Guides](https://hexdocs.pm/phoenix/overview.html)
   - Introduction
     - Except for _Community_
   - Guides

--- a/README.md
+++ b/README.md
@@ -579,8 +579,15 @@ $ cat /tmp/colima/another-file
 ### Phoenix
 *Estimate reading time: 40 hours*
 
-- [Phoenix in Action](https://www.manning.com/books/phoenix-in-action)
-    - All chapters except 2 and 12
+- [Phoenix Official Guides](https://hexdocs.pm/phoenix/up_and_running.html)
+  - Introduction
+    - Except for _Community_
+  - Guides
+    - Except for _Telemetry_ and _Asset Management_
+  - Authentication
+  - Testing
+    - Except for _Testing Channels_
+
 - [Phoenix Chat Example](https://github.com/dwyl/phoenix-chat-example)
 
 **Installing Phoenix**

--- a/README.md
+++ b/README.md
@@ -577,8 +577,6 @@ $ cat /tmp/colima/another-file
 - [StreamData: Property-based testing and data generation](https://elixir-lang.org/blog/2017/10/31/stream-data-property-based-testing-and-data-generation-for-elixir/)
 
 ### Phoenix
-*Estimate reading time: 40 hours*
-
 - [Phoenix Official Guides](https://hexdocs.pm/phoenix/up_and_running.html)
   - Introduction
     - Except for _Community_


### PR DESCRIPTION
The book _Phoenix in Action_ is outdated as of today, and some of its code examples no longer apply to Phoenix current version. This PR replaces _Phoenix in Action_ with some sections from the official Phoenix Documentation. The sections to read were chosen taking the chapters that were required from the book as a basis, so the subjects covered should be the same but with updated information.