### PR TITLE
Readings update

### DIFF
--- a/src/readings.md
+++ b/src/readings.md
@@ -1,9 +1,13 @@
 # Group Readings
 
+Once a week we meet to discuss one or more articules.
+
+Each session elegimos una persona para llevar adelante la siguiente.
+
 ## Unit 1: General Software Engineering
 
 ### Session: Lambda's Engineering Philosophy
-  - [Lambda's Engineering Philosophy](https://blog.lambdaclass.com/lambdas-engineering-philosophy/)
+- [Lambda's Engineering Philosophy](https://blog.lambdaclass.com/lambdas-engineering-philosophy/)
 
 ### Session: Grug 1
 - [The Grug Brained Developer](https://grugbrain.dev)
@@ -13,9 +17,6 @@
   - Agile
   - Refactoring
   - Chesterton's Fence
-
-### Session: Grug 2
-- [The Grug Brained Developer](https://grugbrain.dev)
   - Microservices
   - Tools
   - Type Systems
@@ -23,7 +24,7 @@
   - DRY
   - Separation of Concerns (SoC)
 
-### Session: Grug 3
+### Session: Grug 2
 - [The Grug Brained Developer](https://grugbrain.dev)
   - Closures
   - Logging
@@ -31,9 +32,6 @@
   - Optimizing
   - APIs
   - Parsing
-
-### Session: Grug 4
-- [The Grug Brained Developer](https://grugbrain.dev)
   - The Visitor Pattern
   - Front End Development
   - Fads
@@ -53,22 +51,16 @@
 - [What "Worse is Better vs The Right Thing" is really about](https://yosefk.com/blog/what-worse-is-better-vs-the-right-thing-is-really-about.html)
 - [Worse is Better (is Worse (is Better))](https://olano.dev/blog/worse-is-better-is-worse-is-better)
 
-### Session: Write code that is easy to delete
+### Session: Code is not forever
 - [Write Code that is easy to delete not easy to extend](https://programmingisterrible.com/post/139222674273/write-code-that-is-easy-to-delete-not-easy-to)
-
-### Session: Negotiable Abstractions
 - [Negotiable Abstractions](https://ferd.ca/negotiable-abstractions.html)
 
-## Unit 2 Best Practices: Testing
-
-### Session: Unit Testing?
+### Session: Testing?
 - [Why Most Unit Testing is Waste](https://bulldozer00.blog/wp-content/uploads/2015/03/why-most-unit-testing-is-waste.pdf)
 - [Why Most Unit Testing is Waste???](https://codingcraftsman.wordpress.com/2021/07/10/why-most-unit-testing-is-waste/)
-
-### Session: Mocking
 - [Why Mocking Data is a Bad Practice for Testing](https://medium.com/@queenskisivuli/why-mocking-data-is-a-bad-practice-for-testing-a20d2d7104aa)
 
-## Unit 3 Data Bases & Distributed Systems
+## Unit 2 Data Bases & Distributed Systems
 
 ### Session: N+1 Query Problem
 - [What is the N+1 Query Problem and How to Solve it?](https://planetscale.com/blog/what-is-n-1-query-problem-and-how-to-solve-it)
@@ -79,10 +71,7 @@
 ### Session: The Log Part 2
 - [The Log: What every software engineer should know about real-time data's unifying abstraction](https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying)
 
-### Session: Queues Don't Fix Overload
-- [Queues Don't Fix Overload](https://ferd.ca/queues-don-t-fix-overload.html)
-
-## Unit 4 Performance Engineering
+## Unit 3 Performance Engineering
 
 ### Session: Arena Allocator
 - [Untangling Lifetimes: The Arena Allocator](https://www.rfleury.com/p/untangling-lifetimes-the-arena-allocator)
@@ -91,18 +80,16 @@
 - [CppCon 2014: Mike Acton "Data-Oriented Design and C++"](https://www.youtube.com/watch?v=rX0ItVEVjHc)
 - [Andrew Kelley Practical Data Oriented Design (DoD)](https://www.youtube.com/watch?v=IroPQ150F6c)
 
-## Unit 5 Crypto & Blockchain
+## Unit 4 Crypto & Blockchain
 
 ### Session: Transforming the Future
 - [Transforming the Future with Zero-Knowledge Proofs, Fully Homomorphic Encryption and new Distributed Systems algorithms](https://blog.lambdaclass.com/transforming-the-future-with-zero-knowledge-proofs-fully-homomorphic-encryption-and-new-distributed-systems-algorithms/)
-
-### Session: My techno-optimism
 - [My techno-optimism](https://vitalik.eth.limo/general/2023/11/27/techno_optimism.html)
 
 ### Session: Electronification, Trading, and Crypto
 - [Electronification, Trading, and Crypto](https://blog.uniswap.org/electronification-trading-and-crypto)
 
-## Unit 6 Gaming
+## Unit 5 Gaming
 
 ### Session: 1500 Archers on a 28.8: Network Programming in Age of Empires
 - [1500 Archers on a 28.8: Network Programming in Age of Empires and Beyond](https://zoo.cs.yale.edu/classes/cs538/readings/papers/terrano_1500arch.pdf)

--- a/src/readings.md
+++ b/src/readings.md
@@ -1,8 +1,14 @@
 # Group Readings
 
-Once a week we meet to discuss one or more articules.
+Once a week we meet to discuss one or more articles, blog posts, book chapters, or presentations.
+We find that these articles either have content very relevant to the experience of working at lambdaclass, or align with our principles, or at least give excellent talking points.
+They constitute part of our folklore and shared language and as such we think it's important to make sure everyone is familiar with them, even if you don't agree or can't yet see the point when it requires having gone through some experience. Some of them are controversial on purpose!
+This is why the goal of the activity is not just to read the articles or watch the talks but also to discuss and relate their contents to your experience.
+Ideally everyone should participate, and each session someone is chosen to lead the next one.
 
-Each session elegimos una persona para llevar adelante la siguiente.
+The contents are organized into several units, roughly grouped by topic, and each unit is organized into sessions with group one or more items.
+The sessions are held in round robin fashion, so when the last one is done we start over. Don't worry if we are in the middle of it when you join, you'll come round eventually.
+Once you'ved participated in all sessions participation in the reading group is no longer required but you're welcome anyway. Sometimes views change over time, and hearing from more senior members gives perspective.
 
 ## Unit 1: General Software Engineering
 


### PR DESCRIPTION
- Added intro
- Merged 'write code easy to delete' and 'negotiable abstractions' into one session'
- Merged 'mocking' and 'unit testing' into one session
- Folded the testing unit into the software engineering unit
- Removed 'queues don't fix overload'
- Merged 'transforming the future' and 'my techno-optimism' into one session